### PR TITLE
fix(table-generator): run the CLI when invoked from a Windows path

### DIFF
--- a/packages/table-generator/src/cli.ts
+++ b/packages/table-generator/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 
 import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { updateAppsTable } from "./index.js";
 
 /**
@@ -85,8 +86,11 @@ function main() {
   }
 }
 
-// Run if this script is executed directly
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Run if this script is executed directly.
+// process.argv[1] is a filesystem path, so it has to be converted to a file
+// URL before comparing: interpolating it directly never matches on Windows,
+// nor on any path that needs percent-encoding.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
     main();
   } catch (error) {


### PR DESCRIPTION
Summary

The entry point guard compares `import.meta.url` with a template string built from `process.argv[1]`, which is a filesystem path and not a URL, so it never matches on Windows or on any path that needs percent encoding. `main()` never runs, and `pnpm update-table` and `pnpm check-table` both exit 0 without doing anything.

Now compares against `pathToFileURL(process.argv[1]).href`.

Tests

Before, `tsx src/cli.ts --help` printed nothing and exited 0. After, it prints the help text.

After, `tsx src/cli.ts --check` runs the scan and reports the table status instead of exiting silently.

`biome check` clean on the changed file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file CLI bootstrap fix with no auth, data, or API surface changes; restores intended behavior on Windows.
> 
> **Overview**
> Fixes the **table-generator** CLI so `main()` actually runs when the script is executed directly.
> 
> The direct-execution check compared `import.meta.url` to `` `file://${process.argv[1]}` ``, which is wrong because `process.argv[1]` is a filesystem path, not a URL. That guard never matched on Windows (drive letters, backslashes) or when paths need percent-encoding, so `pnpm update-table` / `pnpm check-table` could exit 0 without updating or checking anything.
> 
> The guard now uses `pathToFileURL(process.argv[1]).href` for a proper file-URL comparison, with a short comment explaining why.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f318f8e05d3318097a1264f30c0b22fd25d779dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->