### PR TITLE
fix(ai-image-generation): add missing /shelby base path to blob URL

### DIFF
--- a/apps/ai-image-generation/.env.example
+++ b/apps/ai-image-generation/.env.example
@@ -1,5 +1,5 @@
 # Shelby Protocol Configuration
-NEXT_PUBLIC_SHELBY_API_URL=https://api.shelbynet.shelby.xyz
+NEXT_PUBLIC_SHELBY_API_URL=https://api.shelbynet.shelby.xyz/shelby
 
 # AI Service API Keys
 OPENAI_API_KEY=your_openai_api_key_here


### PR DESCRIPTION
Summary

`NEXT_PUBLIC_SHELBY_API_URL` points at the host root, so `GeneratedImages` builds `https://api.shelbynet.shelby.xyz/v1/blobs/...`. That path is served by the Aptos fullnode, which has no such route, so every image in the gallery 404s. The blob service is mounted under `/shelby`, which the app's own upload hook and the README already use.

Tests

`curl https://api.shelbynet.shelby.xyz/v1/blobs/<account>/test.png` returns `{"message":"not found","error_code":"web_framework_error","vm_error_code":null}`, the fullnode's router 404.

`curl https://api.shelbynet.shelby.xyz/shelby/v1/blobs/<account>/test.png` returns `{"error":"Blob not found","message":"Blob test.png does not exist for account 0x1"}`, so the route resolves and the account and blob name are parsed.

With the corrected value, the URL the gallery builds is identical to the one `useUploadImageToShelby.tsx` already returns after an upload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line example env change only; no runtime code changes, but correct local `.env` values are required for images to load.
> 
> **Overview**
> Updates **`NEXT_PUBLIC_SHELBY_API_URL`** in **`.env.example`** from the API host root to **`https://api.shelbynet.shelby.xyz/shelby`**.
> 
> The gallery builds image URLs as `{NEXT_PUBLIC_SHELBY_API_URL}/v1/blobs/...`. Without the **`/shelby`** prefix, those requests hit the Aptos fullnode (which has no blob route) and **404**; with it, they match the blob service path already used in the README and upload flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dfc4d9dc109014283bf6acca8b3d7b50cf62a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->